### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image-success.yml
+++ b/.github/workflows/docker-image-success.yml
@@ -18,7 +18,7 @@ jobs:
       - name: BuildDockerImage
         run: docker build . --file Dockerfile --tag kevin0217/testgit:${{ github.ref_name	 }}
       - name: Publish to Docker Repository
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kevin0217/testgit:${{ github.ref_name	 }}
           repository: kevin0217/testgit


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore